### PR TITLE
make explicit call to python3

### DIFF
--- a/binary_clock.md
+++ b/binary_clock.md
@@ -57,6 +57,6 @@ sudo nano /etc/rc.local
 ```
 2. Add following before exit 0.
 ```
-/home/pi/binary-clock/clock.py &
+python3 /home/pi/binary-clock/clock.py &
 ```
 


### PR DESCRIPTION
We had to explicitly call python3 to get this to autostart. It appeared to default to 2.7 when executing rc.local.